### PR TITLE
Execute eyebase request up to 5 times if the API is not available

### DIFF
--- a/src/Staempfli/Eyebase/ContentConverter.php
+++ b/src/Staempfli/Eyebase/ContentConverter.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * ContentConverter
+ *
+ * @copyright Copyright © 2017 Staempfli AG. All rights reserved.
+ * @author    juan.alonso@staempfli.com
+ */
+
+namespace Staempfli\Eyebase;
+
+
+class ContentConverter
+{
+    public function convertContentToArray(string $content) : array
+    {
+        $json = $this->convertContentToJson($content);
+        return json_decode($json, true);
+    }
+
+    public function convertContentToJson(string $content) : string
+    {
+        $xml = $this->convertContentToXml($content);
+        return json_encode($xml);
+    }
+
+    public function convertContentToXml(string $content) : \SimpleXMLElement
+    {
+        return simplexml_load_string($content, null, LIBXML_NOCDATA);
+    }
+
+}

--- a/src/Staempfli/Eyebase/Exception/InvalidXmlContentException.php
+++ b/src/Staempfli/Eyebase/Exception/InvalidXmlContentException.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * InvalidXmlContentException
+ *
+ * @copyright Copyright © 2017 Staempfli AG. All rights reserved.
+ * @author    juan.alonso@staempfli.com
+ */
+
+namespace Staempfli\Eyebase\Exception;
+
+
+class InvalidXmlContentException extends \Exception
+{
+}

--- a/src/Staempfli/Eyebase/Logger.php
+++ b/src/Staempfli/Eyebase/Logger.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Logger
+ *
+ * @copyright Copyright © 2017 Staempfli AG. All rights reserved.
+ * @author    juan.alonso@staempfli.com
+ */
+
+namespace Staempfli\Eyebase;
+
+class Logger
+{
+    private $logsPath;
+
+    public function __construct()
+    {
+        $this->logsPath = __DIR__ . '/../../../log';
+    }
+
+    /**
+     * @param mixin $code
+     * @param string $message
+     */
+    public function error($code, string $message)
+    {
+        $errorLogFilename = $this->logsPath . '/error.log';
+        $message = sprintf("[%s] Error with code: %s \n %s", date("d-m-Y h:i:s"), $code, $message);
+        file_put_contents($errorLogFilename, $message, FILE_APPEND);
+    }
+
+}

--- a/src/Staempfli/Eyebase/Validation.php
+++ b/src/Staempfli/Eyebase/Validation.php
@@ -40,10 +40,7 @@ class Validation
 
     /**
      * @param string $content
-     * @throws EmptyFolderException
-     * @throws LoginErrorException
-     * @throws \Exception
-     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     * @throws InvalidXmlContentException
      */
     public function validateContent(string $content)
     {
@@ -53,20 +50,33 @@ class Validation
         }
         $xml = $this->contentConverter->convertContentToXml($content);
         if (isset($xml->error)) {
-            switch ((int) $xml->error->id) {
-                case self::ERROR_CODE_EMPTY_FOLDER:
-                    throw new EmptyFolderException((string) $xml->error->message);
-                    break;
-                case self::ERROR_CODE_INVALID_FOLDER:
-                    throw new InvalidFolderException((string) $xml->error->message);
-                    break;
-                case self::ERROR_CODE_LOGIN_ERROR;
-                    throw new LoginErrorException((string) $xml->error->eyebase_message);
-                    break;
-                default:
-                    throw new \Exception($this->contentConverter->convertContentToJson($content));
-                    break;
-            }
+            $this->throwXmlContentErrorException($xml, $content);
+        }
+    }
+
+    /**
+     * @param $xml
+     * @param string $content
+     * @throws EmptyFolderException
+     * @throws InvalidFolderException
+     * @throws LoginErrorException
+     * @throws \Exception
+     */
+    private function throwXmlContentErrorException($xml, string $content)
+    {
+        switch ((int) $xml->error->id) {
+            case self::ERROR_CODE_EMPTY_FOLDER:
+                throw new EmptyFolderException((string) $xml->error->message);
+                break;
+            case self::ERROR_CODE_INVALID_FOLDER:
+                throw new InvalidFolderException((string) $xml->error->message);
+                break;
+            case self::ERROR_CODE_LOGIN_ERROR;
+                throw new LoginErrorException((string) $xml->error->eyebase_message);
+                break;
+            default:
+                throw new \Exception($this->contentConverter->convertContentToJson($content));
+                break;
         }
     }
 }

--- a/src/Staempfli/Eyebase/Validation.php
+++ b/src/Staempfli/Eyebase/Validation.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Validation
+ *
+ * @copyright Copyright © 2017 Staempfli AG. All rights reserved.
+ * @author    juan.alonso@staempfli.com
+ */
+
+namespace Staempfli\Eyebase;
+
+use Psr\Http\Message\ResponseInterface;
+use Staempfli\Eyebase\Exception\EmptyFolderException;
+use Staempfli\Eyebase\Exception\InvalidFolderException;
+use Staempfli\Eyebase\Exception\InvalidResponseException;
+use Staempfli\Eyebase\Exception\InvalidXmlContentException;
+use Staempfli\Eyebase\Exception\LoginErrorException;
+
+class Validation
+{
+    const ERROR_CODE_EMPTY_FOLDER = 260;
+    const ERROR_CODE_INVALID_FOLDER = 290;
+    const ERROR_CODE_LOGIN_ERROR = 300;
+
+    /**
+     * @var ContentConverter
+     */
+    private $contentConverter;
+
+    public function __construct()
+    {
+        $this->contentConverter = new ContentConverter();
+    }
+
+    public function validateResponse(ResponseInterface $response)
+    {
+        if ($response->getReasonPhrase() !== 'OK') {
+            throw new InvalidResponseException(sprintf('%s', $response->getReasonPhrase()));
+        }
+    }
+
+    /**
+     * @param string $content
+     * @throws EmptyFolderException
+     * @throws LoginErrorException
+     * @throws \Exception
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     */
+    public function validateContent(string $content)
+    {
+        if (false === @simplexml_load_string($content, null)) {
+            throw new InvalidXmlContentException(
+                sprintf("Error trying to convert following content to xml: \n%s", $content));
+        }
+        $xml = $this->contentConverter->convertContentToXml($content);
+        if (isset($xml->error)) {
+            switch ((int) $xml->error->id) {
+                case self::ERROR_CODE_EMPTY_FOLDER:
+                    throw new EmptyFolderException((string) $xml->error->message);
+                    break;
+                case self::ERROR_CODE_INVALID_FOLDER:
+                    throw new InvalidFolderException((string) $xml->error->message);
+                    break;
+                case self::ERROR_CODE_LOGIN_ERROR;
+                    throw new LoginErrorException((string) $xml->error->eyebase_message);
+                    break;
+                default:
+                    throw new \Exception($this->contentConverter->convertContentToJson($content));
+                    break;
+            }
+        }
+    }
+}

--- a/src/log/.gitignore
+++ b/src/log/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
Execute eyebase request up to 5 times if the API is not available. This happens if the response returns non XML code or too many redirects