### PR TITLE
Remove InvalidXmlContentException from API call retry loop

### DIFF
--- a/src/Staempfli/Eyebase/Eyebase.php
+++ b/src/Staempfli/Eyebase/Eyebase.php
@@ -8,7 +8,6 @@ namespace Staempfli\Eyebase;
 use Doctrine\Instantiator\Exception\InvalidArgumentException;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\TooManyRedirectsException;
-use Staempfli\Eyebase\Exception\InvalidXmlContentException;
 
 /**
  * Class Eyebase
@@ -174,9 +173,6 @@ abstract class Eyebase
 
     private function apiClientNotAvailableException(\Exception $exception): bool
     {
-        if ($exception instanceof InvalidXmlContentException) {
-            return true;
-        }
         if ($exception instanceof TooManyRedirectsException) {
             return true;
         }


### PR DESCRIPTION
The reason of this exception is that the API session was interrupted, if someone else logs in with same credentials. Because of that the exception must not be considered to retry the call. Retrying will not make any different because the session cannot be recovered.